### PR TITLE
изменение VkTransl на VkTranslator.

### DIFF
--- a/Examples/s131235/pom.xml
+++ b/Examples/s131235/pom.xml
@@ -44,7 +44,7 @@
                             <addClasspath>true</addClasspath>
                         </manifest>
                         <manifestEntries>
-                            <Export-Package>ru.mirea.oop.practice.coursej.s131235.VkTransl</Export-Package>
+                            <Export-Package>ru.mirea.oop.practice.coursej.s131235.VkTranslator</Export-Package>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/Examples/s131235/src/main/java/ru/mirea/oop/practice/coursej/s131235/VkTranslator.java
+++ b/Examples/s131235/src/main/java/ru/mirea/oop/practice/coursej/s131235/VkTranslator.java
@@ -9,11 +9,11 @@ import java.io.IOException;
 /**
  * Created by TopKek on 12.12.2015.
  */
-public class VkTransl extends ServiceBotsExtension {
-    private static final Logger logger = LoggerFactory.getLogger(VkTransl.class);
+public class VkTranslator extends ServiceBotsExtension {
+    private static final Logger logger = LoggerFactory.getLogger(VkTranslator.class);
     private boolean alreadySend = false;
 
-    public VkTransl() throws Exception {
+    public VkTranslator() throws Exception {
         super("vk.services.VkTransl");
     }
 

--- a/Examples/s131235/src/main/java/ru/mirea/oop/practice/coursej/s131235/VkTranslator.java
+++ b/Examples/s131235/src/main/java/ru/mirea/oop/practice/coursej/s131235/VkTranslator.java
@@ -14,7 +14,7 @@ public class VkTranslator extends ServiceBotsExtension {
     private boolean alreadySend = false;
 
     public VkTranslator() throws Exception {
-        super("vk.services.VkTransl");
+        super("vk.services.VkTranslator");
     }
 
     @Override

--- a/Examples/s131235/src/main/resources/META-INF/services/ru.mirea.oop.practice.coursej.api.ext.BotsExtension
+++ b/Examples/s131235/src/main/resources/META-INF/services/ru.mirea.oop.practice.coursej.api.ext.BotsExtension
@@ -1,1 +1,1 @@
-ru.mirea.oop.practice.coursej.s131235.VkTransl
+ru.mirea.oop.practice.coursej.s131235.VkTranslator

--- a/Examples/starter/src/main/resources/services.properties
+++ b/Examples/starter/src/main/resources/services.properties
@@ -9,6 +9,5 @@ vk.services.VkBot=false
 vk.services.WeatherInfo=false
 vk.clients.MusicList=false
 vk.clients.PhotoList=false
-vk.services.VkTransl=false
-vk.clients.MusicSync=true
-
+vk.services.VkTranslator=false
+vk.clients.MusicSync=false


### PR DESCRIPTION
в services.properties для запуска используется старое название VkTransl

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/basepractice/2015.2/57)
<!-- Reviewable:end -->
